### PR TITLE
Correct build.yml for workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: Pull Request Build and Test
 
 on:
   push:
-    branches:
-      - "**"
     branches-ignore:
       - master
   pull_request:


### PR DESCRIPTION
Removed branches section from pull because only 1 is allowed. Either branches or branches-ignore and it was causing the workflow to fail.